### PR TITLE
Deterministically compute policy IDs from their contents

### DIFF
--- a/tests/cases/condition/outputs/output_1.json
+++ b/tests/cases/condition/outputs/output_1.json
@@ -1,5 +1,5 @@
 {
-    "Id": "123",
+    "Id": "81fefc67a48059db6c9ab32607e6de8a",
     "Statement": [
         {
             "Action": [

--- a/tests/cases/different_principals/outputs/output_1.json
+++ b/tests/cases/different_principals/outputs/output_1.json
@@ -1,5 +1,5 @@
 {
-    "Id": "123",
+    "Id": "aa19d49457324b0a5a7eb9ebec5a638f",
     "Statement": [
         {
             "Action": [

--- a/tests/cases/multipass/outputs/output_1.json
+++ b/tests/cases/multipass/outputs/output_1.json
@@ -1,5 +1,5 @@
 {
-    "Id": "Whoa",
+    "Id": "2d910f13d7f0a6d2b79deb517a83e2df",
     "Version": "2012-10-17",
     "Statement": [
         {

--- a/tests/cases/notaction/outputs/output_1.json
+++ b/tests/cases/notaction/outputs/output_1.json
@@ -1,5 +1,5 @@
 {
-    "Id": "123",
+    "Id": "14f75b38b79b86ae1e0ce0075ea91985",
     "Statement": [
         {
             "Action": [

--- a/tests/cases/notresource/outputs/output_1.json
+++ b/tests/cases/notresource/outputs/output_1.json
@@ -1,5 +1,5 @@
 {
-    "Id": "123",
+    "Id": "c1d5c6cf5b05702e77aa1704cf8a26a8",
     "Statement": [
         {
             "Action": [

--- a/tests/cases/shadowed/outputs/output_1.json
+++ b/tests/cases/shadowed/outputs/output_1.json
@@ -1,5 +1,5 @@
 {
-    "Id": "123",
+    "Id": "f6954ea1f63c46e212fd53043faf8a64",
     "Statement": [
         {
             "Action": [

--- a/tests/cases/trivial/outputs/output_1.json
+++ b/tests/cases/trivial/outputs/output_1.json
@@ -1,5 +1,5 @@
 {
-    "Id": "123",
+    "Id": "8daffc991c342ece96a90c3c712564dd",
     "Statement": [
         {
             "Action": [

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -35,7 +35,4 @@ def test_named_case(case_name, tmp_path):
         expected_output = json.loads(path.read_text())
         actual_output = json.loads((tmp_path / path.name).read_text())
 
-        expected_output.pop("Id")
-        actual_output.pop("Id")
-
         assert expected_output == actual_output

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -31,7 +31,9 @@ def test_write_policy_leaves_expected_results(tmp_path):
         (tmp_path / f"foo_bar_{i}.json").write_text('{"what": "fnord"}')
 
     written = policy.write_policy_set(
-        tmp_path, "foo", [{"foo": "something"}, {"bar": "something"}]
+        tmp_path,
+        "foo",
+        [{"Statement": {"foo": "something"}}, {"Statement": {"bar": "something"}}],
     )
 
     assert written == [f"{tmp_path}/foo_1.json", f"{tmp_path}/foo_2.json"]
@@ -51,13 +53,19 @@ def test_write_policy_leaves_expected_results(tmp_path):
     assert (tmp_path / "foo_1.json").read_text() == textwrap.dedent(
         """\
         {
-            "foo": "something"
+            "Id": "e4cd4ec6c23f8cf878f22c99b6edf909",
+            "Statement": {
+                "foo": "something"
+            }
         }"""
     )
     assert (tmp_path / "foo_2.json").read_text() == textwrap.dedent(
         """\
         {
-            "bar": "something"
+            "Id": "35fda171edeffab70d23db34d53e3f80",
+            "Statement": {
+                "bar": "something"
+            }
         }"""
     )
 
@@ -91,7 +99,6 @@ def test_policy_combine_small():
     assert len(policies) == 1
 
     new_policy = policies[0]
-    del new_policy["Id"]
     assert new_policy == {
         "Version": "2012-10-17",
         "Statement": [{"Action": "Dance!", "Resource": "Disco"}],
@@ -114,14 +121,10 @@ def test_policy_combine_big():
 
     new_policy_1, new_policy_2 = policies
 
-    del new_policy_1["Id"]
-
     assert new_policy_1 == {
         "Version": "2012-10-17",
         "Statement": [{"Action": ["a" * a_len, "c" * c_len], "NotResource": "spam"}],
     }
-
-    del new_policy_2["Id"]
 
     assert new_policy_2 == {
         "Version": "2012-10-17",


### PR DESCRIPTION
This is a pretty tiny code change that makes the output policy ID a hash of its contents. This means that creating a policy is deterministic: the same inputs will always generate the same outputs, which Git and Terraform will love.