### PR TITLE
Model policies as a class

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max_line_length = 99

--- a/tests/cases/condition/outputs/output_1.json
+++ b/tests/cases/condition/outputs/output_1.json
@@ -1,5 +1,6 @@
 {
-    "Id": "81fefc67a48059db6c9ab32607e6de8a",
+    "Version": "2012-10-17",
+    "Id": "d615d6c49722d2f4052e7d9b9fc8f4d7",
     "Statement": [
         {
             "Action": [
@@ -18,6 +19,5 @@
             "Effect": "Allow",
             "Resource": "*"
         }
-    ],
-    "Version": "2012-10-17"
+    ]
 }

--- a/tests/cases/different_principals/outputs/output_1.json
+++ b/tests/cases/different_principals/outputs/output_1.json
@@ -1,5 +1,6 @@
 {
-    "Id": "aa19d49457324b0a5a7eb9ebec5a638f",
+    "Version": "2012-10-17",
+    "Id": "17364a895fb4c0b5d5efa4a0786024fd",
     "Statement": [
         {
             "Action": [
@@ -29,6 +30,5 @@
             "Principal": "arn:some_resource2",
             "Resource": "*"
         }
-    ],
-    "Version": "2012-10-17"
+    ]
 }

--- a/tests/cases/multipass/outputs/output_1.json
+++ b/tests/cases/multipass/outputs/output_1.json
@@ -1,5 +1,5 @@
 {
-    "Id": "2d910f13d7f0a6d2b79deb517a83e2df",
+    "Id": "fcd8ee21aa42cc033b7144a0d50a9cfb",
     "Version": "2012-10-17",
     "Statement": [
         {

--- a/tests/cases/notaction/outputs/output_1.json
+++ b/tests/cases/notaction/outputs/output_1.json
@@ -1,5 +1,6 @@
 {
-    "Id": "14f75b38b79b86ae1e0ce0075ea91985",
+    "Version": "2012-10-17",
+    "Id": "a7c738a04e1da29fb1351fd87dfc81fa",
     "Statement": [
         {
             "Action": [
@@ -15,6 +16,5 @@
             "Effect": "Allow",
             "Resource": "*"
         }
-    ],
-    "Version": "2012-10-17"
+    ]
 }

--- a/tests/cases/notresource/outputs/output_1.json
+++ b/tests/cases/notresource/outputs/output_1.json
@@ -1,5 +1,6 @@
 {
-    "Id": "c1d5c6cf5b05702e77aa1704cf8a26a8",
+    "Version": "2012-10-17",
+    "Id": "9a0cce91ee80f13c415a913e4523153b",
     "Statement": [
         {
             "Action": [
@@ -23,6 +24,5 @@
             "Effect": "Allow",
             "NotResource": "some_resource"
         }
-    ],
-    "Version": "2012-10-17"
+    ]
 }

--- a/tests/cases/shadowed/outputs/output_1.json
+++ b/tests/cases/shadowed/outputs/output_1.json
@@ -1,5 +1,6 @@
 {
-    "Id": "f6954ea1f63c46e212fd53043faf8a64",
+    "Version": "2012-10-17",
+    "Id": "81ae08b722646d014d79f6f931361b98",
     "Statement": [
         {
             "Action": [
@@ -9,6 +10,5 @@
             "Effect": "Allow",
             "Resource": "*"
         }
-    ],
-    "Version": "2012-10-17"
+    ]
 }

--- a/tests/cases/trivial/outputs/output_1.json
+++ b/tests/cases/trivial/outputs/output_1.json
@@ -1,5 +1,6 @@
 {
-    "Id": "8daffc991c342ece96a90c3c712564dd",
+    "Version": "2012-10-17",
+    "Id": "2d266525adae71eeac1d3ec2a1e4c0d8",
     "Statement": [
         {
             "Action": [
@@ -9,6 +10,5 @@
             "Effect": "Allow",
             "Resource": "*"
         }
-    ],
-    "Version": "2012-10-17"
+    ]
 }

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -5,7 +5,7 @@ import pathlib
 
 import pytest
 
-from wonk import models, policy
+from wonk import cli, policy
 
 # Get the path to the "cases" directory that lives next to this module
 CASE_BASE = pathlib.Path(__file__).parent / "cases"
@@ -23,7 +23,7 @@ def test_named_case(case_name, tmp_path):
     input_paths = (test_base / "inputs").glob("*.json")
     assert input_paths
 
-    inputs = [models.Policy.from_dict(json.loads(path.read_text())) for path in input_paths]
+    inputs = cli.policies_from_filenames(input_paths)
     combined = policy.combine(inputs)
 
     policy.write_policy_set(tmp_path, "output", combined)

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -5,7 +5,7 @@ import pathlib
 
 import pytest
 
-from wonk import policy
+from wonk import models, policy
 
 # Get the path to the "cases" directory that lives next to this module
 CASE_BASE = pathlib.Path(__file__).parent / "cases"
@@ -23,7 +23,7 @@ def test_named_case(case_name, tmp_path):
     input_paths = (test_base / "inputs").glob("*.json")
     assert input_paths
 
-    inputs = [json.loads(path.read_text()) for path in input_paths]
+    inputs = [models.Policy.from_dict(json.loads(path.read_text())) for path in input_paths]
     combined = policy.combine(inputs)
 
     policy.write_policy_set(tmp_path, "output", combined)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,7 @@
 """Test the wonk.models module."""
 
+from string import ascii_lowercase
+
 import pytest
 
 from wonk import models
@@ -297,3 +299,24 @@ def test_policy_render():
             ),
         ]
     )
+
+
+def test_split_statement():
+    """Statements are correctly split into smaller chunks."""
+
+    splitted = models.InternalStatement(
+        {"Action": list(ascii_lowercase), "Resource": "foo"}
+    ).split_statement(100)
+
+    assert next(splitted) == {
+        "Action": ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+        "Resource": "foo",
+    }
+    assert next(splitted) == {
+        "Action": ["j", "k", "l", "m", "n", "o", "p", "q", "r"],
+        "Resource": "foo",
+    }
+    assert next(splitted) == {
+        "Action": ["s", "t", "u", "v", "w", "x", "y", "z"],
+        "Resource": "foo",
+    }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -169,13 +169,13 @@ def test_canonicalize_resources_wildcards():
 def test_grouping_for_actions(statement, expected):
     """Statements can be grouped by their expected key."""
 
-    assert models.InternalStatement(statement).grouping_for_actions() == expected
+    assert models.Statement(statement).grouping_for_actions() == expected
 
 
 def test_sorting_key():
     """Ensure sorting keys have the expected shape and are ordered correctly."""
 
-    statement1 = models.InternalStatement(STATEMENT_WITH_CONDITION)
+    statement1 = models.Statement(STATEMENT_WITH_CONDITION)
 
     sorting_key1 = statement1.sorting_key()
 
@@ -193,7 +193,7 @@ def test_sorting_key():
         ["SVC:Action1", "SVC:Action2", "SVC:Action3"],
     )
 
-    statement2 = models.InternalStatement(STATEMENT_DENY_NOTRESOURCE)
+    statement2 = models.Statement(STATEMENT_DENY_NOTRESOURCE)
 
     sorting_key2 = statement2.sorting_key()
 
@@ -208,7 +208,7 @@ def test_sorting_key():
         ["SVC:BadAction1", "SVC:BadAction4"],
     )
 
-    statement3 = models.InternalStatement(STATEMENT_SIMPLE)
+    statement3 = models.Statement(STATEMENT_SIMPLE)
 
     sorting_key3 = statement3.sorting_key()
 
@@ -228,13 +228,13 @@ def test_sorting_key_sorts_correctly():
     """The output of sorting_key is orderable in the expected way."""
 
     # This will come second because it has an Action, and Effect=Allow, and Resource=*.
-    statement1 = models.InternalStatement(STATEMENT_WITH_CONDITION)
+    statement1 = models.Statement(STATEMENT_WITH_CONDITION)
 
     # This will come third because it has a NotAction, and a specific NotResource.
-    statement2 = models.InternalStatement(STATEMENT_DENY_NOTRESOURCE)
+    statement2 = models.Statement(STATEMENT_DENY_NOTRESOURCE)
 
     # This will come first because it's the simplest statement.
-    statement3 = models.InternalStatement(STATEMENT_SIMPLE)
+    statement3 = models.Statement(STATEMENT_SIMPLE)
 
     assert sorted((statement1, statement2, statement3), key=lambda obj: obj.sorting_key()) == [
         statement3,
@@ -247,7 +247,7 @@ def test_policy_render():
     """A rendered policy looks like we'd expect it to."""
 
     # This should be output last because it's just some random statement.
-    statement_1 = models.InternalStatement(
+    statement_1 = models.Statement(
         {
             "Effect": "Deny",
             "Action": {"SVC:BadAction1", "SVC:BadAction4"},
@@ -256,7 +256,7 @@ def test_policy_render():
     )
 
     # This should be output second because it's the NotAction version of the minimal statement.
-    statement_2 = models.InternalStatement(
+    statement_2 = models.Statement(
         {
             "Effect": "Allow",
             "NotAction": {"SVC:OtherAction1", "SVC:OtherAction5"},
@@ -265,7 +265,7 @@ def test_policy_render():
     )
 
     # This should be output first because it's the minimal statement.
-    statement_3 = models.InternalStatement(
+    statement_3 = models.Statement(
         {
             "Effect": "Allow",
             "Action": {"SVC:Action1", "SVC:Action2", "SVC:Action3"},
@@ -301,9 +301,7 @@ def test_policy_render():
 def test_split_statement():
     """Statements are correctly split into smaller chunks."""
 
-    splitted = models.InternalStatement(
-        {"Action": list(ascii_lowercase), "Resource": "foo"}
-    ).split(100)
+    splitted = models.Statement({"Action": list(ascii_lowercase), "Resource": "foo"}).split(100)
 
     assert next(splitted) == {
         "Action": ["a", "b", "c", "d", "e", "f", "g", "h", "i"],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 """Test the wonk.models module."""
 
+import json
 from string import ascii_lowercase
 
 import pytest
@@ -272,33 +273,29 @@ def test_policy_render():
         }
     )
 
-    rendered = models.Policy(statements=[statement_1, statement_2, statement_3])
+    rendered = models.Policy(statements=[statement_1, statement_2, statement_3]).render()
 
-    assert rendered == models.Policy(
-        statements=[
-            models.InternalStatement(
-                {
-                    "Action": ["SVC:Action1", "SVC:Action2", "SVC:Action3"],
-                    "Effect": "Allow",
-                    "Resource": "*",
-                }
-            ),
-            models.InternalStatement(
-                {
-                    "Action": ["SVC:BadAction1", "SVC:BadAction4"],
-                    "Effect": "Deny",
-                    "Resource": "*",
-                }
-            ),
-            models.InternalStatement(
-                {
-                    "Effect": "Allow",
-                    "NotAction": ["SVC:OtherAction1", "SVC:OtherAction5"],
-                    "Resource": "*",
-                }
-            ),
-        ]
-    )
+    assert json.loads(rendered) == {
+        "Version": "2012-10-17",
+        "Id": "2f2e3ef90177f911cf7382d4719a78b7",
+        "Statement": [
+            {
+                "Action": ["SVC:Action1", "SVC:Action2", "SVC:Action3"],
+                "Effect": "Allow",
+                "Resource": "*",
+            },
+            {
+                "Action": ["SVC:BadAction1", "SVC:BadAction4"],
+                "Effect": "Deny",
+                "Resource": "*",
+            },
+            {
+                "Effect": "Allow",
+                "NotAction": ["SVC:OtherAction1", "SVC:OtherAction5"],
+                "Resource": "*",
+            },
+        ],
+    }
 
 
 def test_split_statement():
@@ -306,7 +303,7 @@ def test_split_statement():
 
     splitted = models.InternalStatement(
         {"Action": list(ascii_lowercase), "Resource": "foo"}
-    ).split_statement(100)
+    ).split(100)
 
     assert next(splitted) == {
         "Action": ["a", "b", "c", "d", "e", "f", "g", "h", "i"],

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -164,19 +164,6 @@ def test_policy_combine_big():
     )
 
 
-def test_split_statement():
-    """Statements are correctly split into smaller chunks."""
-
-    splitted = policy.split_statement(
-        {"Action": ["a"] * 45 + ["b"] * 30 + ["c"] * 30 + ["d"] * 15}, 300
-    )
-
-    assert next(splitted) == {"Action": ["a"] * 30}
-    assert next(splitted) == {"Action": ["a"] * 15 + ["b"] * 15}
-    assert next(splitted) == {"Action": ["b"] * 15 + ["c"] * 15}
-    assert next(splitted) == {"Action": ["c"] * 15 + ["d"] * 15}
-
-
 def test_grouped_actions():
     """Simple statements are grouped as expected, even if their resources are written oddly."""
 

--- a/wonk/models.py
+++ b/wonk/models.py
@@ -3,12 +3,20 @@
 import copy
 import json
 import re
-from typing import Any, Dict, List, Set, Tuple, Union
+from hashlib import sha256
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from .constants import ACTION_KEYS, JSON_ARGS, RESOURCE_KEYS, StatementKey
+from .constants import (
+    ACTION_KEYS,
+    JSON_ARGS,
+    MAX_MANAGED_POLICY_SIZE,
+    RESOURCE_KEYS,
+    PolicyKey,
+    StatementKey,
+)
+from .exceptions import UnshrinkablePolicyError
 
 Statement = Dict[str, Any]
-Policy = Dict[str, Any]
 
 
 class InternalStatement:
@@ -124,6 +132,89 @@ class InternalStatement:
             len(self.action_value),
             # The values of the actions
             sorted(self.action_value),
+        )
+
+
+class Policy:
+    """Represent an AWS policy."""
+
+    version: str
+    id_: Optional[str]
+    statement: Any
+
+    DEFAULT_ID = "*" * 32
+
+    def __init__(self, *, version=None, id=None, statement=None):
+        """Initialize a Policy object."""
+
+        self.version = "2012-10-17" if version is None else version
+        self.id_ = self.DEFAULT_ID if id is None else id
+        self.statement = [] if statement is None else statement
+
+    def __repr__(self) -> str:
+        """Return a string representation of the Policy."""
+
+        name = self.__class__.__name__
+
+        return f"{name}(version={self.version!r}, id={self.id!r}, statement={self.statement!r})"
+
+    def __eq__(self, other) -> bool:
+        """Return True if this Policy is identical to the other one."""
+
+        return (
+            self.version == other.version
+            and self.id == other.id
+            and self.statement == other.statement
+        )
+
+    def as_json(self) -> Dict[str, Any]:
+        """Represent the Policy as a JSON object."""
+
+        return {
+            PolicyKey.VERSION: self.version,
+            PolicyKey.ID: self.id,
+            PolicyKey.STATEMENT: self.statement,
+        }
+
+    def render(self) -> str:
+        """Return the most aesthetic representation of the Policy that fits in the size."""
+
+        data = self.as_json()
+        for args in JSON_ARGS:
+            packed = json.dumps(data, **args)
+            if len(packed) <= MAX_MANAGED_POLICY_SIZE:
+                return packed
+
+        raise UnshrinkablePolicyError(
+            f"Unable to shrink the data into into {MAX_MANAGED_POLICY_SIZE} characters: {data!r}"
+        )
+
+    def tiniest_json(self) -> str:
+        """Return the smallest possible JSON representation of the object."""
+
+        data = {
+            PolicyKey.VERSION: self.version,
+            PolicyKey.ID: self.DEFAULT_ID,  # Don't compute the Policy's ID just for this.
+            PolicyKey.STATEMENT: self.statement,
+        }
+
+        return json.dumps(data, sort_keys=True, **JSON_ARGS[-1])
+
+    @property
+    def id(self) -> str:
+        """Return the Policy's ID as a hash of its contents."""
+
+        digest = sha256(self.tiniest_json().encode()).hexdigest()
+        return digest[: len(self.DEFAULT_ID)]
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a Policy object from a dictionary."""
+
+        return cls(
+            version=data.pop(PolicyKey.VERSION, None),
+            id=data.pop(PolicyKey.ID, None),
+            statement=data.pop(PolicyKey.STATEMENT, None),
         )
 
 

--- a/wonk/models.py
+++ b/wonk/models.py
@@ -191,7 +191,11 @@ class Policy:
         if isinstance(self.statements, dict):
             self.__setattr__("statements", [self.statements])
 
-    #        self.statements.sort(key=lambda statement: statement.sorting_key())
+        # Sort everything that can be sorted. This ensures that separate runs of the program
+        # generate the same outputs, which 1) makes `git diff` happy, and 2) lets us later check to
+        # see if we're actually updating a policy that we've written out, and if so, skip writing
+        # it again (with a new `Id` key).
+        self.statements.sort(key=lambda statement: statement.sorting_key())
 
     def __eq__(self, other) -> bool:
         """Return True if this Policy is identical to the other one."""

--- a/wonk/models.py
+++ b/wonk/models.py
@@ -3,7 +3,7 @@
 import copy
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass, field
 from hashlib import sha256
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -168,28 +168,14 @@ class InternalStatement:
         )
 
 
+@dataclass(frozen=True)
 class Policy:
     """Represent an AWS policy."""
 
-    version: str
-    id_: Optional[str]
-    statement: Any
-
     DEFAULT_ID = "*" * 32
 
-    def __init__(self, *, version=None, id=None, statement=None):
-        """Initialize a Policy object."""
-
-        self.version = "2012-10-17" if version is None else version
-        self.id_ = self.DEFAULT_ID if id is None else id
-        self.statement = [] if statement is None else statement
-
-    def __repr__(self) -> str:
-        """Return a string representation of the Policy."""
-
-        name = self.__class__.__name__
-
-        return f"{name}(version={self.version!r}, id={self.id!r}, statement={self.statement!r})"
+    statement: List[Statement]
+    version: str = field(default="2012-10-17")
 
     def __eq__(self, other) -> bool:
         """Return True if this Policy is identical to the other one."""
@@ -246,7 +232,6 @@ class Policy:
 
         return cls(
             version=data.pop(PolicyKey.VERSION, None),
-            id=data.pop(PolicyKey.ID, None),
             statement=data.pop(PolicyKey.STATEMENT, None),
         )
 

--- a/wonk/models.py
+++ b/wonk/models.py
@@ -288,7 +288,7 @@ def to_set(value: Union[str, List[str]]) -> Set[str]:
 
 
 def value_to_set(statement: Statement, key: str) -> Set[str]:
-    """Return the content's of the statements key as a (possibly empty) set of strings."""
+    """Return the contents of the statements key as a (possibly empty) set of strings."""
 
     try:
         value = statement[key]

--- a/wonk/models.py
+++ b/wonk/models.py
@@ -172,7 +172,7 @@ class InternalStatement:
             sorted(self.action_value),
         )
 
-    def split_statement(self, max_statement_size: int) -> Generator[Statement, None, None]:
+    def split(self, max_statement_size: int) -> Generator[Statement, None, None]:
         """Split the original statement into a series of chunks that are below the size limit."""
 
         statement_action = self.action_key
@@ -217,9 +217,7 @@ class Policy:
             self.__setattr__("statements", [self.statements])
 
         # Sort everything that can be sorted. This ensures that separate runs of the program
-        # generate the same outputs, which 1) makes `git diff` happy, and 2) lets us later check to
-        # see if we're actually updating a policy that we've written out, and if so, skip writing
-        # it again (with a new `Id` key).
+        # generate the same outputs, which makes `git diff` happy.
         self.statements.sort(key=InternalStatement.sorting_key)
 
     def __eq__(self, other) -> bool:

--- a/wonk/policy.py
+++ b/wonk/policy.py
@@ -95,16 +95,6 @@ def grouped_resources(statements: List[InternalStatement]) -> Tuple[bool, List[I
     return changed, list(statement_sets.values())
 
 
-def render(statements: List[InternalStatement]) -> Policy:
-    """Turn the contents of the statement sets into a valid AWS policy."""
-
-    # Sort everything that can be sorted. This ensures that separate runs of the program generate
-    # the same outputs, which 1) makes `git diff` happy, and 2) lets us later check to see if we're
-    # actually updating a policy that we've written out, and if so, skip writing it again (with a
-    # new `Id` key).
-    return Policy(statements=sorted(statements, key=lambda obj: obj.sorting_key()))
-
-
 def tiniest_json(data: Statement) -> str:
     """Return the smallest representation of the data."""
     return json.dumps(data, sort_keys=True, **JSON_ARGS[-1])
@@ -137,7 +127,7 @@ def split_statement(
 def combine(policies: List[Policy]) -> List[Policy]:
     """Combine policy files into the smallest possible set of outputs."""
 
-    new_policy = render(minify(policies))
+    new_policy = Policy(statements=minify(policies))
 
     # Simplest case: we're able to squeeze everything into a single file. This is the ideal.
     try:
@@ -182,7 +172,7 @@ def combine(policies: List[Policy]) -> List[Policy]:
         unmerged_policy = Policy(
             statements=[InternalStatement(json.loads(statement)) for statement in statement_set]
         )
-        merged_policy = render(minify([unmerged_policy]))
+        merged_policy = Policy(statements=minify([unmerged_policy]))
         policies.append(merged_policy)
 
     return policies

--- a/wonk/policy.py
+++ b/wonk/policy.py
@@ -173,7 +173,7 @@ def combine(policies: List[Policy]) -> List[Policy]:
     # we could fit all n then we wouldn't have made it to this point in the program. And yes, this
     # is exactly the part of the program where we start caring about every byte.
     statements = new_policy.statement
-    minimum_possible_policy_size = len(Policy().tiniest_json())
+    minimum_possible_policy_size = len(Policy(statement=[]).tiniest_json())
     max_number_of_commas = len(statements) - 2
     max_statement_size = (
         MAX_MANAGED_POLICY_SIZE - minimum_possible_policy_size - max_number_of_commas

--- a/wonk/policy.py
+++ b/wonk/policy.py
@@ -194,8 +194,7 @@ def combine(policies: List[Policy]) -> List[Policy]:
         # that could be merged back together. The easiest way to handle this is to create a new
         # policy as-is, then group its statements together into *another* new, optimized policy,
         # and emit that one.
-        unmerged_policy = Policy()
-        unmerged_policy.statement = [json.loads(statement) for statement in statement_set]
+        unmerged_policy = Policy(statement=[json.loads(statement) for statement in statement_set])
         merged_policy = render(minify([unmerged_policy]))
         policies.append(merged_policy)
 

--- a/wonk/policy.py
+++ b/wonk/policy.py
@@ -68,11 +68,12 @@ def grouped_actions(statements: List[InternalStatement]) -> Tuple[bool, List[Int
             existing_item = statement_sets[group]
         except KeyError:
             statement_sets[group] = statement
-        else:
-            new_action_value = existing_item.action_value | statement.action_value
-            if existing_item.action_value != new_action_value:
-                changed = True
-                existing_item.action_value = new_action_value
+            continue
+
+        new_action_value = existing_item.action_value | statement.action_value
+        if existing_item.action_value != new_action_value:
+            changed = True
+            statement_sets[group] = existing_item.replace(action_value=new_action_value)
 
     return changed, list(statement_sets.values())
 
@@ -93,13 +94,14 @@ def grouped_resources(statements: List[InternalStatement]) -> Tuple[bool, List[I
             existing_item = statement_sets[group]
         except KeyError:
             statement_sets[group] = statement
-        else:
-            new_resource_value = canonicalize_resources(
-                to_set(existing_item.resource_value) | to_set(statement.resource_value)
-            )
-            if existing_item.resource_value != new_resource_value:
-                changed = True
-                existing_item.resource_value = new_resource_value
+            continue
+
+        new_resource_value = canonicalize_resources(
+            to_set(existing_item.resource_value) | to_set(statement.resource_value)
+        )
+        if existing_item.resource_value != new_resource_value:
+            changed = True
+            statement_sets[group] = existing_item.replace(resource_value=new_resource_value)
 
     return changed, list(statement_sets.values())
 

--- a/wonk/policy.py
+++ b/wonk/policy.py
@@ -124,7 +124,7 @@ def combine(policies: List[Policy]) -> List[Policy]:
     for statement in new_policy.statements:
         packed = statement.tiniest_json()
         if len(packed) > max_statement_size:
-            for splitted in statement.split_statement(max_statement_size):
+            for splitted in statement.split(max_statement_size):
                 packed_list.append(tiniest_json(splitted))
         else:
             packed_list.append(packed)


### PR DESCRIPTION
The policy / statement / InternalStatement model was getting a bit too complicated to keep a consistent mental model. This change:

- Replaces functions operating on dicts represent policies with a new `Policy` class and appropriate methods.
- More consistently operates on `InternalStatement` models internally.
- Makes `Policy` and `InternalStatement` objects immutable, greatly simplifying how to reason about them.
- Simplifies some code (like `write_policy_set`) thanks to the new properties.

I think this approach makes both the code, and life for developers, simpler.