### PR TITLE
Move the "dict-to-list" function to from_dict

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -315,3 +315,17 @@ def test_split_statement():
         "Action": ["s", "t", "u", "v", "w", "x", "y", "z"],
         "Resource": "foo",
     }
+
+
+def test_policy_from_dict_malformed_ok():
+    """Malformed policies with dicts as their Statement are parsed correctly."""
+
+    rendered = models.Policy.from_dict(
+        {"Statement": {"Effect": "Deny", "Action": "twirl", "Resource": "widget"}}
+    ).render()
+
+    assert json.loads(rendered) == {
+        "Version": "2012-10-17",
+        "Id": "2d8f6cb90c80585ade0580022df5c75a",
+        "Statement": [{"Effect": "Deny", "Action": "twirl", "Resource": "widget"}],
+    }


### PR DESCRIPTION
This moves the "repair AWS malformed policy" fix into import functionality at `from_dict`. That fixes a regression when handling a broken policy.