### PR TITLE
Abstract Policy Sets

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021 Amino
+Copyright 2023 Amino
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.rst
+++ b/README.rst
@@ -237,7 +237,7 @@ the second statement is broader than the first, so the first could be safely rem
 Copyright
 =========
 
-The Policy Wonk is copyright 2021-2022 Amino, Inc. and distributed under the terms of the Apache-2.0 License.
+The Policy Wonk is copyright 2021-2023 Amino, Inc. and distributed under the terms of the Apache-2.0 License.
 
 .. _IAM quotas: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
 .. _jq: https://stedolan.github.io/jq/
@@ -246,6 +246,9 @@ The Policy Wonk is copyright 2021-2022 Amino, Inc. and distributed under the ter
 
 History
 =======
+**0.7.0**
+  2023-03-20: Add 'abstract' option to policy sets (default false). Wonk will not render combined policies for abstract policy sets.
+
 **0.6.1**
   2022-05-20: Important bugfix! Policies large enough to require splitting weren't being processed correctly, causing an exception. This would not have caused data corruption, just a runtime failure.
 

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,11 @@ You **could** write a bunch of ``wonk combine`` command lines, maybe in a shell 
 ::
 
     policy_sets:
+      OnCall:
+        abstract: true
+        local:
+          - OnCall
+
       Backend:
         managed:
           - AWSPolicy1
@@ -88,7 +93,6 @@ You **could** write a bunch of ``wonk combine`` command lines, maybe in a shell 
       BackendOnCall:
         inherits:
           - Backend
-        local:
           - OnCall
 
       Frontend:
@@ -100,7 +104,6 @@ You **could** write a bunch of ``wonk combine`` command lines, maybe in a shell 
       FrontendOnCall:
         inherits:
           - Frontend
-        local:
           - OnCall
 
 and then tell Wonk to build them all for you:
@@ -109,7 +112,7 @@ and then tell Wonk to build them all for you:
 
     $ wonk build --all
 
-which fetches any missing managed policies, then creates a set of combined policies named after their YAML configurations.
+which fetches any missing managed policies, then creates a set of combined policies named after their YAML configurations. Wonk skips building combined policies for abstract policy sets.
 
 A managed policy ``Foo`` is fetched by the ARN ``arn:aws:iam::aws:policy/Foo``. However, some Amazon policies don't follow that convention. In that case, you can give an ARN instead of a policy name and that ARN will be fetched instead (and the policy's name will be derived from the ARN). You could also do that if you want to fetch your own policy from Amazon instead of maintaining it locally.
 
@@ -247,7 +250,7 @@ The Policy Wonk is copyright 2021-2023 Amino, Inc. and distributed under the ter
 History
 =======
 **0.7.0**
-  2023-03-20: Add 'abstract' option to policy sets (default false). Wonk will not render combined policies for abstract policy sets.
+  2023-03-20: Add 'abstract' option to policy sets (default false). Wonk skips building combined policies for abstract policy sets.
 
 **0.6.1**
   2022-05-20: Important bugfix! Policies large enough to require splitting weren't being processed correctly, causing an exception. This would not have caused data corruption, just a runtime failure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wonk"
-version = "0.6.1"
+version = "0.7.0"
 description = "Wonk is a tool for combining a set of AWS policy files into smaller compiled policy sets."
 license = "Apache-2.0"
 authors = ["Kirk Strauser <kirk@amino.com>"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,63 @@
+"""Wonk CLI command unit tests."""
+
+from argparse import Namespace
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+import yaml
+
+from wonk.cli import command_line_build
+from wonk.models import Policy
+
+
+@pytest.fixture
+def wonk_tempdir():
+    """A temporary directory setup to run wonk commands."""
+
+    with TemporaryDirectory() as tmpdir:
+        dir_path = Path(tmpdir)
+
+        for subfolder in ["managed", "local", "combined"]:
+            subfolder_path = dir_path / subfolder
+            subfolder_path.mkdir()
+
+        yield dir_path
+
+
+@pytest.fixture
+def wonk_yaml_abstract(wonk_tempdir):
+    """A wonk.yaml file with an abstract policy set."""
+
+    config = {
+        "policy_sets": {
+            "PolicyA": {
+                "abstract": True,
+            },
+            "PolicyB": {
+                "inherits": ["PolicyA"],
+            },
+        }
+    }
+
+    wonk_yaml_path = wonk_tempdir / "wonk.yaml"
+    wonk_yaml_path.write_text(yaml.dump(config))
+    return wonk_yaml_path
+
+
+def test_command_line_build__abstract(wonk_tempdir, wonk_yaml_abstract, mocker):
+    """Should skip building abstract policy sets."""
+
+    mock_write = mocker.patch("wonk.cli.write_policy_set")
+
+    args = Namespace(
+        config=wonk_yaml_abstract,
+        path=wonk_tempdir,  # cwd
+        all=True,
+    )
+
+    command_line_build(args)
+
+    # Wonk does not attempt to build abstract policy set PolicyA
+    expected_combined = [Policy(statements=[], version="2012-10-17")]
+    mock_write.assert_called_once_with(wonk_tempdir, "PolicyB", expected_combined)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,30 +11,45 @@ def test_parse_config():
     conf = config.parse_config(
         {
             "policy_sets": {
+                "Poultry": {
+                    "abstract": True,
+                    "managed": ["Squawk"],
+                    "local": ["file2"],
+                },
                 "Spam": {
                     "managed": ["Foo"],
                     "local": ["file1"],
                 },
                 "Eggs": {
                     "managed": ["Bar"],
-                    "inherits": ["Spam"],
+                    "inherits": ["Poultry", "Spam"],
                 },
                 "Qux": {},
             }
         }
     )
 
+    assert conf.policy_sets["Poultry"].managed == ["Squawk"]
+    assert conf.policy_sets["Poultry"].local == ["file2"]
+    assert conf.policy_sets["Poultry"].abstract
+
     assert conf.policy_sets["Spam"].managed == ["Foo"]
     assert conf.policy_sets["Spam"].local == ["file1"]
     assert not conf.policy_sets["Spam"].inherits
+    assert not conf.policy_sets["Spam"].abstract
 
-    assert conf.policy_sets["Eggs"].managed == ["Bar", "Foo"]
-    assert conf.policy_sets["Eggs"].local == ["file1"]
-    assert conf.policy_sets["Eggs"].inherits == ["Spam"]
+    # The order of 'managed' and 'local' policies is stable based on the order
+    # parent policies are inherited. Since 'Poultry' is inherited first, its
+    # managed and local policies come first in these lists.
+    assert conf.policy_sets["Eggs"].managed == ["Bar", "Squawk", "Foo"]
+    assert conf.policy_sets["Eggs"].local == ["file2", "file1"]
+    assert conf.policy_sets["Eggs"].inherits == ["Poultry", "Spam"]
+    assert not conf.policy_sets["Eggs"].abstract
 
     assert not conf.policy_sets["Qux"].managed
     assert not conf.policy_sets["Qux"].local
     assert not conf.policy_sets["Qux"].inherits
+    assert not conf.policy_sets["Qux"].abstract
 
 
 def test_parse_config_minimal():

--- a/wonk/__init__.py
+++ b/wonk/__init__.py
@@ -1,3 +1,3 @@
 """The Policy Wonk."""
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/wonk/cli.py
+++ b/wonk/cli.py
@@ -30,6 +30,12 @@ def command_line_build(args):
 
     for policy_set_name in policy_set_names:
         config = full_config.policy_sets[policy_set_name]
+
+        # Don't build combined policies for abstract policy sets
+        if config.abstract:
+            print(f"Skipping abstract policy set {policy_set_name}")
+            continue
+
         input_filenames = []
 
         for managed_policy in config.managed:

--- a/wonk/cli.py
+++ b/wonk/cli.py
@@ -24,12 +24,12 @@ def command_line_build(args):
         sys.exit(1)
 
     if args.all:
-        policy_sets = full_config.policy_sets.keys()
+        policy_set_names = full_config.policy_sets.keys()
     else:
-        policy_sets = args.policy_set
+        policy_set_names = args.policy_set
 
-    for policy_set in policy_sets:
-        config = full_config.policy_sets[policy_set]
+    for policy_set_name in policy_set_names:
+        config = full_config.policy_sets[policy_set_name]
         input_filenames = []
 
         for managed_policy in config.managed:
@@ -50,10 +50,10 @@ def command_line_build(args):
             input_filenames.append(f"local/{local_policy}.json")
 
         policies = policies_from_filenames(input_filenames)
-        output_filenames = write_policy_set(args.path, policy_set, combine(policies))
+        output_filenames = write_policy_set(args.path, policy_set_name, combine(policies))
 
         print()
-        print(f"Created the following files for policy set {policy_set}:")
+        print(f"Created the following files for policy set {policy_set_name}:")
         print()
         for filename in output_filenames:
             print(f"- {filename}")

--- a/wonk/config.py
+++ b/wonk/config.py
@@ -17,6 +17,7 @@ class PolicySet(BaseModel):
     managed: List[str] = []
     local: List[str] = []
     inherits: List[str] = []
+    abstract: bool = False
 
     def __ior__(self, other):
         """Append the values from another policy set onto this one's."""

--- a/wonk/policy.py
+++ b/wonk/policy.py
@@ -175,7 +175,7 @@ def write_policy_set(output_dir: pathlib.Path, base_name: str, policies: List[Po
     for old in cleanup:
         old.unlink()
 
-    # Write each of the files that file go into this policy set, and create a list of the filenames
+    # Write each of the files that go into this policy set, and create a list of the filenames
     # we've written.
     output_filenames = []
     for i, policy in enumerate(policies, 1):


### PR DESCRIPTION
## Overview

This PR adds the concept of "abstract" policy sets. Wonk now skips building combined policies when a policy set specifies `abstract: true`. However, wonk still reads the configuration of abstract policy sets and combines their `managed` and `local` policies with those of the "concrete" policy sets that depend on them.